### PR TITLE
Bug Fix: Race Conditions in Processing History Archiving & Add File Locking

### DIFF
--- a/packages/backend/shared/gcp.ts
+++ b/packages/backend/shared/gcp.ts
@@ -5,8 +5,7 @@ import dotenv from 'dotenv';
 
 dotenv.config({ path: path.resolve(__dirname, '../.env') });
 
-// GKE workloads compatible
-const storage = new Storage(); 
+const storage = new Storage();
 
 export const uploadToGCS = async (
   bucketName: string,
@@ -16,7 +15,7 @@ export const uploadToGCS = async (
 ): Promise<void> => {
   try {
     const bucket = storage.bucket(bucketName);
-    
+
     // If content is provided and file doesn't exist, create it
     if (content && !fs.existsSync(filePath)) {
       const dir = path.dirname(filePath);

--- a/packages/backend/shared/types.ts
+++ b/packages/backend/shared/types.ts
@@ -43,8 +43,10 @@ export interface ProcessingRecord {
 
 export interface ProcessingHistory {
   records: ProcessingRecord[];
+  lastArchiveTimestamp?: string | null;
   archivedRecords?: {
     path: string;
     count: number;
+    timestamp: string;
   }[];
-} 
+}


### PR DESCRIPTION
**Description:**  
This pull request addresses issues with the processing history update logic, specifically:

- **Race Conditions & Concurrent Updates:**  
  The processing history was being updated concurrently from multiple network processes (Ethereum and ZKSync). This led to race conditions where both processes read and updated the same file concurrently, resulting in duplicate and excessive archiving events.

- **Excessive Archiving:**  
  Due to the race condition, the archive logic was triggered far too frequently, creating an excessive number of archive files. Additionally, the previous threshold and timelock settings were not aligned with the intended archive frequency (i.e., once every few days).

**Changes Made:**

1. **Implemented File-Based Locking:**  
   - Added `acquireLock` and `releaseLock` functions to create a lock file before updating the processing history file.  
   - This ensures that only one process can update the history at any given time, preventing overlapping writes and duplicate archiving events.

2. **Updated Archive Logic:**  
   - Modified the archive threshold and timelock conditions to only trigger archiving when the record count reaches a specified threshold (now set to 1000) and when a minimum time interval has passed since the last archive.
   - Corrected the timelock calculation to use the proper millisecond value (e.g., using `10 * 60 * 1000` for 10 minutes, or updated to a longer duration for a few days if needed).
   - Adjusted retention logic so that after archiving, a configurable number of recent records are preserved (currently keeping the last 100 records, but this can be modified as needed).

3. **Improved Logging:**  
   - Added more detailed console log messages throughout the process to aid in debugging and ensure that lock acquisition, archiving, and file updates are clearly recorded.

**Why These Changes Were Necessary:**  
- **Preventing Data Loss & Duplication:**  
  By preventing concurrent updates, we avoid scenarios where updates from one process overwrite or conflict with another, which previously resulted in an unexpectedly low record count and frequent archive file creation.

- **Controlling Archive Frequency:**  
  The revised archive conditions ensure that archives occur only when necessary (e.g., every 1000 records and not more frequently than the configured timelock), thereby keeping the processing history manageable and reducing unnecessary file uploads to GCS.

- **System Stability & Maintainability:**  
  With proper locking and clearer thresholds, the system becomes more robust and easier to maintain, particularly as the cronjob runs every 10 minutes in production.

### Results of the bug:
![image](https://github.com/user-attachments/assets/494d9e5f-19ba-4a9b-b6b6-4f9826316589)

### Steps to resolve:
1. Delete the following folder (state folder, which contains archive and processing-history.json)
<img width="707" alt="image" src="https://github.com/user-attachments/assets/48599d75-acc7-44ba-8430-971d5d1c1324" />

3. merge this pr, pull, build to docker, then continue to run the cronjob (note: no need to run the init/process-historic-blocks function since the rss feed wasn't affected)
4. this bug doesn't effect the rss feed (it's still catching and rendering events), but is creating excessive logging files in gcp, so at a minimum delete the folder
